### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.1
+
+* Updated files to work with latest CI updates
+
 ## 1.0.0
 
 * Drop Python 2.7 support

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 1.0.1
 
-* Updated files to work with latest CI updates
+* Updated files to work with latest CI updates.
 
 ## 1.0.0
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - phantomjs
   - browser
   - headless browser
-version: 1.0.0
+version: 1.0.1
 author: Tomaz Muraus
 email: tomaz@tomaz.me
 python_versions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-selenium
+selenium==3.3.0


### PR DESCRIPTION
Fixed files to work with latest CI updates:

- PhantomJS was removed from selenium module after v3.3.0
    - https://stackoverflow.com/a/72415296
- It seems like this pack can be archived as people are switching to modern headless browsers instead of using PhantomJS
    - https://www.browserstack.com/guide/attributeerror-selenium
    - https://github.com/StackStorm-Exchange/stackstorm-phantomjs/issues/6